### PR TITLE
Plugin/WriteExcel.pm: simply die on errors

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'Mojolicious', '5.73';
+requires 'Mojolicious', '9.25';
 requires 'Spreadsheet::WriteExcel::Simple', '1.04';
 
 on test => sub {

--- a/lib/Mojolicious/Plugin/WriteExcel.pm
+++ b/lib/Mojolicious/Plugin/WriteExcel.pm
@@ -27,7 +27,7 @@ sub xls_renderer {
   }
 
   if (ref $settings) {
-    $c->reply->exception("invalid column width")
+    die "invalid column width"
       unless defined $settings->{column_width};
     for my $col (keys %{$settings->{column_width}}) {
       $ss->sheet->set_column($col, $settings->{column_width}->{$col});


### PR DESCRIPTION
We no longer need to call `$c->reply->exception` (introduced in #4) as this will force Mojo to call the renderer again and trigger a new exception introduced in Mojo 9.25 - just use `die` instead.

Fixes #5.